### PR TITLE
Add optional --output-directory argument for specifying the output directory for the generated sbom files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ No external Python packages are required (script uses standard library modules o
 Run from the repository root:
 
 ```bash
-python src/automation_sbom_parserV1.py <project_directory> [--export-libraries] [--installation-directory <path>] [--customer-name <name>]
+python src/automation_sbom_parserV1.py <project_directory> [--export-libraries] [--installation-directory <path>] [--customer-name <name>] [--output-directory <path>]
 ```
 
 ### Arguments
@@ -60,6 +60,8 @@ python src/automation_sbom_parserV1.py <project_directory> [--export-libraries] 
 - `--customer-name <name>` (optional)
    - Used as supplier value for non-B&R components.
    - Default: `UNKNOWN`
+- `--output-directory <path>` (optional)
+   - Path to the directory where to write the generated SBOM files. Falls back to the `<project_directory>` if omitted.
 
 ## Samples
 
@@ -78,13 +80,25 @@ python src/automation_sbom_parserV1.py example/Repro6 --export-libraries --custo
 python src/automation_sbom_parserV1.py example/Repro6 --installation-directory "D:/BRAutomation/AS6" --customer-name "Demo Customer"
 ```
 
+### Sample 4: Use a custom relative output directory (relative to the current working directory)
+This would create output files to the `./sbom` directory
+```bash
+python src/automation_sbom_parserV1.py example/Repro6 --installation-directory "D:/BRAutomation/AS6" --customer-name "Demo Customer" --output-directory sbom
+```
+
+### Sample 5: Use a custom absolute output directory
+This would create output fiels to the `D:/SBOM` directory
+```bash
+python src/automation_sbom_parserV1.py example/Repro6 --installation-directory "D:/BRAutomation/AS6" --customer-name "Demo Customer" --output-directory "D:/SBOM"
+```
+
 ### Windows absolute path sample
 ```bash
 python src/automation_sbom_parserV1.py "C:/Projects/MyAsProject" --installation-directory "C:/Program Files (x86)/BRAutomation/AS6" --export-libraries --customer-name "ACME"
 ```
 
 ## Output
-- The script creates one JSON file per configuration in the given project directory.
+- The script creates one JSON file per configuration in the given output directory or project directory if --output-directory is not provided.
 - Filename pattern:
    - `<ConfigurationName>_sbom.json`
 - Example outputs:

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ python src/automation_sbom_parserV1.py example/Repro6 --installation-directory "
 ### Sample 4: Use a custom relative output directory (relative to the current working directory)
 This would create output files to the `./sbom` directory
 ```bash
-python src/automation_sbom_parserV1.py example/Repro6 --installation-directory "D:/BRAutomation/AS6" --customer-name "Demo Customer" --output-directory sbom
+python src/automation_sbom_parserV1.py example/Repro6 --customer-name "Demo Customer" --output-directory sbom
 ```
 
 ### Sample 5: Use a custom absolute output directory
 This would create output fiels to the `D:/SBOM` directory
 ```bash
-python src/automation_sbom_parserV1.py example/Repro6 --installation-directory "D:/BRAutomation/AS6" --customer-name "Demo Customer" --output-directory "D:/SBOM"
+python src/automation_sbom_parserV1.py example/Repro6 --customer-name "Demo Customer" --output-directory "D:/SBOM"
 ```
 
 ### Windows absolute path sample

--- a/src/automation_sbom_parserV1.py
+++ b/src/automation_sbom_parserV1.py
@@ -14,7 +14,7 @@ import hashlib
 import uuid
 import argparse  # Add argparse for command-line argument parsing
 
-SCRIPT_VERSION = "1.1.0"
+SCRIPT_VERSION = "1.2.0"
 
 #TODO Set correct paths if installation directory is provided for AS4
 #TODO Create a alternative parsing method for AS4, since the structure in the installation directory is different to AS6
@@ -26,11 +26,18 @@ VC_FIRMWARE_PATH = "AS/VC/Firmware"
 HARDWARE_MODULES_PATH = "AS/Hardware/Modules"
 
 class AutomationStudioSBOMGenerator:
-    def __init__(self, project_path: str, export_libraries: bool, installation_directory: str, customer_name: str):
+    def __init__(self, project_path: str, export_libraries: bool, installation_directory: str, customer_name: str, output_directory: str | None = None):
         self.project_path = Path(project_path)
         self.export_libraries = export_libraries  # Store the switch value
         self.installation_directory = Path(installation_directory)
         self.customer_name = customer_name
+        self.output_directory = Path(output_directory) if output_directory else self.project_path
+        if self.output_directory.exists():
+            if not self.output_directory.is_dir():
+                print(f" ⚠️  Output directory is not a directory: {self.output_directory}")
+                exit(-1)
+        else:
+            self.output_directory.mkdir(parents=True, exist_ok=True)
         self.components = {}  # Initialize as a dictionary to store components per configuration
 
     def CollectAutomationStudioProjectInformation(self):
@@ -810,7 +817,7 @@ class AutomationStudioSBOMGenerator:
             ]
             
             # Write the SBOM to a JSON file
-            output_path = self.project_path / f"{config}_{output_file}"
+            output_path = self.output_directory / f"{config}_{output_file}"
             with open(output_path, 'w') as f:
                 json.dump(sbom, f, indent=4)
             print(f"  ✅ SBOM generated for configuration '{config}' at: {output_path}")
@@ -830,8 +837,17 @@ if __name__ == "__main__":
     parser.add_argument(
         "--customer-name", default="UNKNOWN", help="Customer name to be used in the licence, supplier, description and CPE fields. If not provided, 'UNKNOWN' will be used."
     )
+    parser.add_argument(
+        "--output-directory", default=None, help="Directory to write the generated SBOM files. Defaults to the project directory."
+    )
     args = parser.parse_args()
 
-    generator = AutomationStudioSBOMGenerator(args.project_directory, args.export_libraries, args.installation_directory, args.customer_name)
+    generator = AutomationStudioSBOMGenerator(
+        args.project_directory,
+        args.export_libraries,
+        args.installation_directory,
+        args.customer_name,
+        args.output_directory,
+    )
     generator.generate_sbom()
 


### PR DESCRIPTION
Add optional argument

- `--output-directory <path>` (optional)
   - Path to the directory where to write the generated SBOM files. Falls back to the `<project_directory>` if omitted.

### Sample 4: Use a custom relative output directory (relative to the current working directory)
This would create output files to the `./sbom` directory
```bash
python src/automation_sbom_parserV1.py example/Repro6 --installation-directory "D:/BRAutomation/AS6" --customer-name "Demo Customer" --output-directory sbom
```

### Sample 5: Use a custom absolute output directory
This would create output fiels to the `D:/SBOM` directory
```bash
python src/automation_sbom_parserV1.py example/Repro6 --installation-directory "D:/BRAutomation/AS6" --customer-name "Demo Customer" --output-directory "D:/SBOM"
```

Resolves #1 