### PR TITLE
Extensions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.zip
 *.7z
-
+/.venv
 # Ignore AR versions as those are not considered part of the project
 /**/AS/System/
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ python src/automation_sbom_parserV1.py <project_directory> [--export-libraries] 
    - Default: `UNKNOWN`
 - `--output-directory <path>` (optional)
    - Path to the directory where to write the generated SBOM files. Falls back to the `<project_directory>` if omitted.
+- `--no-fancy` (optional)
+  - replaces all '⚠️' with 'WARNING', '🔍' with 'INFO', '✅' with 'SUCCESS' and '🛠️' with 'DEBUG'
+- `--license-name <name>` (optional)
+  - if set, this license name will be set for all non B&R libraries as licensename in the SBOM
+- `--license-url <url>` (optional)
+  - if set, this license url will be set for all non B&R libraries as licenseurl in the SBOM
 
 ## Samples
 

--- a/README.md
+++ b/README.md
@@ -98,10 +98,26 @@ This would create output fiels to the `D:/SBOM` directory
 python src/automation_sbom_parserV1.py example/Repro6 --customer-name "Demo Customer" --output-directory "D:/SBOM"
 ```
 
-### Windows absolute path sample
+### Sample 6: Windows absolute path sample
 ```bash
 python src/automation_sbom_parserV1.py "C:/Projects/MyAsProject" --installation-directory "C:/Program Files (x86)/BRAutomation/AS6" --export-libraries --customer-name "ACME"
 ```
+
+### Sample 7: default license for non B&R Libraries and Tasks
+```bash
+python src/automation_sbom_parserV1.py "C:/Projects/MyAsProject" --output-directory "D:/SBOM" --export-libraries --customer-name "UniCon Team" --license-name "default-license" --license-url "www.default-license.com"
+```
+
+## License information in .var File
+open a local .var File as text and insert the following comment:
+```
+(*
+"License name": "$name$"
+"License URL": "$url$"
+*)
+```
+can also be used to create a Code snippet in AS
+"Variable Decleration Snippets"
 
 ## Output
 - The script creates one JSON file per configuration in the given output directory or project directory if --output-directory is not provided.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ python src/automation_sbom_parserV1.py <project_directory> [--export-libraries] 
    - Default: `UNKNOWN`
 - `--output-directory <path>` (optional)
    - Path to the directory where to write the generated SBOM files. Falls back to the `<project_directory>` if omitted.
-- `--no-fancy` (optional)
+- `--no-icons` (optional)
   - replaces all '⚠️' with 'WARNING', '🔍' with 'INFO', '✅' with 'SUCCESS' and '🛠️' with 'DEBUG'
 - `--license-name <name>` (optional)
   - if set, this license name will be set for all non B&R libraries as licensename in the SBOM

--- a/src/automation_sbom_parserV1.py
+++ b/src/automation_sbom_parserV1.py
@@ -13,6 +13,7 @@ import hashlib
 import uuid
 import argparse  # Add argparse for command-line argument parsing
 
+
 SCRIPT_VERSION = "1.2.2"
 #TODO Try fetching CVEs from B&R feed
 #TODO Set correct paths if installation directory is provided for AS4
@@ -114,7 +115,7 @@ class AutomationStudioSBOMGenerator:
                         except Exception as e:
                             print(f"  {self.warning}  Error reading {var_file}: {e}")
                             
-        print(f'Lizenzinfos in .var Dateien gefunden: {self.licence_info}')
+        print(f'{self.info} Lizenzinfos in .var Dateien gefunden: {self.licence_info}')
 
     def _find_configurations(self):
         """Parse Physical.pkg to identify configurations."""
@@ -416,6 +417,7 @@ class AutomationStudioSBOMGenerator:
             self._parse_apj_file(config)  # Parse the .apj file to extract AutomationRuntime and VisualizationControl information for the current configuration
             self._parse_cpu_pkg_file(config)  # Parse the cpu.pkg file for the current configuration to extract CPU information and add it to the components list
             self._parse_sw_file(config)  # Parse the .sw files for the current configuration to extract software component information and add it to the components list
+            self._parse_sw_file_tasks(config)  # Parse the .sw files for the current configuration to extract software task information and add it to the components list
             self._parse_hw_file(config)  # Parse the .hw files for the current configuration to extract hardware module information and add it to the components list 
     
     def _parse_automation_runtime_libraries(self):
@@ -704,10 +706,86 @@ class AutomationStudioSBOMGenerator:
 
                         if not _is_br_component:
                             print(f"  {self.warning}  {lib_name} (version: {version}) - User-defined library, not identified as B&R component")
-
+                
             except ET.ParseError:
                 print(f"  {self.warning}  XML parsing error in {sw_file_path}")
 
+    def _parse_sw_file_tasks(self, config=None):
+        """Parse a single .sw file for software component information."""
+        current_sw_file = self.sw_files.get(config)
+        
+        if not current_sw_file:
+            print(f"  {self.warning}  No .sw file found for configuration '{config}'")
+            return
+
+        # Use a namespace dictionary to avoid conflicts with 'http' package
+        ns = {'swcfg': 'http://br-automation.co.at/AS/SwConfiguration'}
+
+        for sw_file_path in current_sw_file:
+            try:
+                tree = ET.parse(sw_file_path)
+                root = tree.getroot()
+
+                # Extract task components
+                for task in root.findall(".//swcfg:Task", namespaces=ns):
+                    task_name = task.get("Name", "unknown")
+                    _language = task.get("Language", "unknown")
+                    _is_disabled = task.get("Disabled", "false")
+                    _description = f"Software Task: '{task_name}'"
+                    _task_version = self._get_task_version(task.get("Source", "TO BE CHECKED BY USER"))
+                    if _is_disabled.lower() == "true":
+                        continue
+
+                    self._add_component(
+                            config=config,
+                            name=task_name,
+                            version=_task_version,
+                            comp_type=f"'{_language}'-task",
+                            is_br_component=False,
+                            description=_description 
+                        )      
+                    
+            except ET.ParseError:
+                print(f"  {self.warning}  XML parsing error in {sw_file_path}")
+                return None
+
+    def _get_task_version(self, task_path):
+        if not task_path.endswith(".prg"):
+            return None
+        
+        # Use a namespace dictionary to avoid conflicts with 'http' package
+        ns = {'swcfg': 'http://br-automation.co.at/AS/SwConfiguration'}
+
+        # den Filepath zusammensetzen aus self.project_path und task_path, um die Version der Task zu ermitteln
+        _task_path = task_path.replace(".prg", "")  # delete ".prg" from the end of the task_path
+        _task_path = _task_path.replace(".", "\\")  # Replace dots with backslashes to form a valid path
+        _logical_path = self.project_path / "Logical"
+        _path = _logical_path / _task_path
+        _prg_files = []
+        _task_version = "1.0.0"
+
+        #self._find_license_info_in_var_files(_path)  # Check for license information in the .var files of the task
+
+        # parse _path for files ending with ".prg" 
+        for file in Path(_path).rglob("*.prg"):
+            _prg_files.append(file.name)
+
+        
+        for _prg_file in _prg_files:
+            try:
+                _prg_file_path = _path / _prg_file
+                tree = ET.parse(_prg_file_path)
+                root = tree.getroot()
+                if "Version" in root.attrib:
+                    _task_version = root.attrib["Version"]
+                    break  # Stop after finding the first version, assuming all .prg files for the task have the same version 
+                    
+            except ET.ParseError:
+                print(f"  {self.warning}  XML parsing error in {_prg_file_path}")
+                return None
+            
+        return _task_version
+    
     def _parse_hw_file(self, config=None):
         """Parse a single .hw file for hardware module information."""
         current_hw_file = self.hw_files.get(config)
@@ -775,6 +853,7 @@ class AutomationStudioSBOMGenerator:
                 }
             }
         else:
+            print(f'Lizenzinfo schreiben: {safe_name}')
             if safe_name in self.licence_info:
                 license_info = {
                     "license": {

--- a/src/automation_sbom_parserV1.py
+++ b/src/automation_sbom_parserV1.py
@@ -884,7 +884,7 @@ if __name__ == "__main__":
         "--output-directory", default=None, help="Directory to write the generated SBOM files. Defaults to the project directory."
     )
     parser.add_argument(
-        "--no-fancy",  action="store_true", help="Disable fancy output formatting."
+        "--no-icons",  action="store_true", help="Disable icon inclusion in the SBOM."
     )
     parser.add_argument(
         "--license-name", default="UNKNOWN", help="Name of the license to be used in the SBOM. If not provided, 'UNKNOWN' will be used."
@@ -900,7 +900,7 @@ if __name__ == "__main__":
         args.installation_directory,
         args.customer_name,
         args.output_directory,
-        args.no_fancy,
+        args.no_icons,
         args.license_name,
         args.license_url
     )

--- a/src/automation_sbom_parserV1.py
+++ b/src/automation_sbom_parserV1.py
@@ -115,7 +115,6 @@ class AutomationStudioSBOMGenerator:
                         except Exception as e:
                             print(f"  {self.warning}  Error reading {var_file}: {e}")
                             
-        print(f'{self.info} Lizenzinfos in .var Dateien gefunden: {self.licence_info}')
 
     def _find_configurations(self):
         """Parse Physical.pkg to identify configurations."""
@@ -515,7 +514,6 @@ class AutomationStudioSBOMGenerator:
                     is_br_component=True,
                     description=f"B&R Automation Studio Version {version} (Working: {working_version})"
                 )
-                #print(f"  ➕ AutomationStudio v{version} (Working: {working_version})")
 
             # Parse the rest of the file for TechnologyPackages
             tree = ET.parse(self.apj_file)
@@ -544,7 +542,6 @@ class AutomationStudioSBOMGenerator:
                     
                     # Store the package name and version in a dictionary
                     self.technology_packages[package_name] = package_version
-                    #print(f"  ➕ TechnologyPackage-{package_name} v{package_version}")
 
         except ET.ParseError:
             print(f"  {self.warning}  XML parsing error in {self.apj_file}")
@@ -578,7 +575,6 @@ class AutomationStudioSBOMGenerator:
                     is_br_component=True,
                     description="B&R Automation Runtime Environment"
                 )
-                #print(f"  ➕ AutomationRuntime v{runtime_version}")
 
             # Extract VisualizationControl
             vc_elem = root.find(".//{http://br-automation.co.at/AS/Cpu}Vc")
@@ -594,7 +590,6 @@ class AutomationStudioSBOMGenerator:
                         description="B&R VC 4"
                     )
                     self.vc_version = vc_version  # Store the version for the current configuration
-                    #print(f"  ➕ VisualizationControl v{vc_version}")
                 
         except ET.ParseError:
             print(f"  {self.warning}  XML parsing error in {current_cpu_pkg}")
@@ -853,7 +848,6 @@ class AutomationStudioSBOMGenerator:
                 }
             }
         else:
-            print(f'Lizenzinfo schreiben: {safe_name}')
             if safe_name in self.licence_info:
                 license_info = {
                     "license": {

--- a/src/automation_sbom_parserV1.py
+++ b/src/automation_sbom_parserV1.py
@@ -25,15 +25,21 @@ VC_FIRMWARE_PATH = "AS/VC/Firmware"
 HARDWARE_MODULES_PATH = "AS/Hardware/Modules"
 
 class AutomationStudioSBOMGenerator:
-    def __init__(self, project_path: str, export_libraries: bool, installation_directory: str, customer_name: str, output_directory: str | None = None):
+    def __init__(self, project_path: str, export_libraries: bool, installation_directory: str, customer_name: str, output_directory: str, no_fancy: bool , license_name: str , license_url: str):
         self.project_path = Path(project_path)
         self.export_libraries = export_libraries  # Store the switch value
         self.installation_directory = Path(installation_directory)
         self.customer_name = customer_name
+        self.license_name_default = license_name
+        self.license_url_default = license_url
         self.output_directory = Path(output_directory) if output_directory else self.project_path
+        self.warning = '⚠️' if not no_fancy else 'WARNING'
+        self.info = '🔍' if not no_fancy else 'INFO'
+        self.success = '✅' if not no_fancy else 'SUCCESS'
+        self.debug = '🛠️' if not no_fancy else 'DEBUG'
         if self.output_directory.exists():
             if not self.output_directory.is_dir():
-                print(f" ⚠️  Output directory is not a directory: {self.output_directory}")
+                print(f" {self.warning}  Output directory is not a directory: {self.output_directory}")
                 exit(-1)
         else:
             self.output_directory.mkdir(parents=True, exist_ok=True)
@@ -41,7 +47,7 @@ class AutomationStudioSBOMGenerator:
 
     def CollectAutomationStudioProjectInformation(self):
         """ Collect all necessary information for the SBOM from the Automation Studio project directory. """
-        print("🔍 Collecting Automation Studio project information...")
+        print(f"{self.info} Collecting Automation Studio project information...")
 
         self._find_apj_file() # information used in all configurations
         self._find_all_libraries_in_logical()
@@ -59,26 +65,56 @@ class AutomationStudioSBOMGenerator:
         apj_files = list(self.project_path.glob("*.apj"))
         if apj_files:
             self.apj_file = apj_files[0]  # Assuming there's only one .apj file
-            print(f"  ✅ Found APJ file: {self.apj_file}")
+            print(f"  {self.success} Found APJ file: {self.apj_file}")
         else:
-            print("  ⚠️  No APJ file found in the project directory.")
+            print(f"  {self.warning}  No APJ file found in the project directory.")
 
     def _find_all_libraries_in_logical(self):
         """List all libraries from the Logical folder of the project."""
         self.libraries_in_logical_files = {}
-
+        
         logical_folder_path = self.project_path / "Logical"
 
         if not logical_folder_path.exists():
-            print(f"  ⚠️  Logical folder path not found: {logical_folder_path}")
+            print(f"  {self.warning}  Logical folder path not found: {logical_folder_path}")
             return []
 
         for subfolder in logical_folder_path.rglob("*"):
             if subfolder.is_dir():
                 potential_lby_file = next(subfolder.glob("*.lby"), None)
-
                 if potential_lby_file:
                     self.libraries_in_logical_files[subfolder.name] = potential_lby_file
+
+        self._find_license_info_in_var_files(logical_folder_path)
+
+    def _find_license_info_in_var_files(self, logical_folder_path: str):
+        _variable_files_in_libraries = {}
+        self.licence_info = {} # "library_name": {"license_name": "name", "license_url": "url"}
+        for subfolder in logical_folder_path.rglob("*"):
+            if subfolder.is_dir():
+                variable_files = list(subfolder.glob("*.var"))
+                if variable_files:
+                    for var_file in variable_files:
+                        # file öffnen, und nach license_name und license_url suchen
+                        try:
+                            with open(var_file, "r", encoding="utf-8") as f:
+                                content = f.read()
+                                license_name = None
+                                license_url = None
+                                for line in content.splitlines():
+                                    if line.startswith('"License name":'):
+                                        license_name = line.split(": ")[1].strip('"')
+                                    elif line.startswith('"License URL":'):
+                                        license_url = line.split(": ")[1].strip('"')
+                                if license_name or license_url:
+                                    self.licence_info[subfolder.name] = {
+                                        "license_name": license_name,
+                                        "license_url": license_url
+                                    }
+                        except Exception as e:
+                            print(f"  {self.warning}  Error reading {var_file}: {e}")
+                            
+        print(f'Lizenzinfos in .var Dateien gefunden: {self.licence_info}')
 
     def _find_configurations(self):
         """Parse Physical.pkg to identify configurations."""
@@ -87,7 +123,7 @@ class AutomationStudioSBOMGenerator:
         physical_pkg_path = self.project_path / "Physical" / "Physical.pkg"
         
         if not physical_pkg_path.exists():
-            print("  ⚠️  Physical.pkg not found")
+            print(f"  {self.warning}  Physical.pkg not found")
             return []
 
         try:
@@ -97,10 +133,10 @@ class AutomationStudioSBOMGenerator:
             # Extract configurations
             self.configurations = [obj.text for obj in root.findall(".//{http://br-automation.co.at/AS/Physical}Object")
                               if obj.get("Type") == "Configuration"]
-            print(f"  🛠️  Found {len(self.configurations)} configurations: {self.configurations}")  # Debug output
+            print(f"  {self.debug}  Found {len(self.configurations)} configurations: {self.configurations}")  # Debug output
 
         except ET.ParseError:
-            print(f"  ⚠️  XML parsing error in {physical_pkg_path}")
+            print(f"  {self.warning}  XML parsing error in {physical_pkg_path}")
             return []
 
     def _find_cpu_pkg_files(self):
@@ -139,7 +175,7 @@ class AutomationStudioSBOMGenerator:
                             files_list.append(full_ref_path)  # Store the full path for later parsing
 
             except ET.ParseError:
-                print(f"  ⚠️  XML parsing error in {pkg_file}")
+                print(f"  {self.warning}  XML parsing error in {pkg_file}")
 
         return files_list
 
@@ -172,7 +208,7 @@ class AutomationStudioSBOMGenerator:
                             self.configuration_ids[config] = configID.get("Value", "unknown")  # Store the configuration ID in the dictionary
                 
                 except ET.ParseError:
-                    print(f"  ⚠️  XML parsing error in {hw_file}")
+                    print(f"  {self.warning}  XML parsing error in {hw_file}")
 
     def _get_configurationVersions(self):
         """Extract the ConfigurationVersion from *.hw files per configuration."""
@@ -190,7 +226,7 @@ class AutomationStudioSBOMGenerator:
                             self.configuration_versions[config] = configVersion.get("Value", "1.0.0")  # Store the configuration version in the dictionary
 
                 except ET.ParseError:
-                    print(f"  ⚠️  XML parsing error in {hw_file}")
+                    print(f"  {self.warning}  XML parsing error in {hw_file}")
             
             if not self.configuration_versions.get(config):
                 self.configuration_versions[config] = "1.0.0"  # If no version is found, default to 1.0.0
@@ -198,7 +234,7 @@ class AutomationStudioSBOMGenerator:
 
     def CollectAutomationStudioInstallationInformation(self):
         """ Collect the information from the Automation Studio installation directory """
-        print("🔍 Collecting Automation Studio installation information...")
+        print(f"{self.info} Collecting Automation Studio installation information...")
 
         self._find_technology_packages()
         self._find_automation_runtime_libraries()
@@ -213,7 +249,7 @@ class AutomationStudioSBOMGenerator:
         base_path = self.installation_directory / TECHNOLOGY_PACKAGES_PATH
 
         if not base_path.exists():
-            print(f"  ⚠️  Technology packages base path not found: {base_path}")
+            print(f"  {self.warning}  Technology packages base path not found: {base_path}")
 
         # interate through all subfolders of the technology package base path and look for .br files 
         # if a .br file is found, add it to the technology_package_files dictionary with the version of the technology package as value, the version can be extracted from the name of the subfolder, which is in the format 6.5.0  
@@ -244,7 +280,7 @@ class AutomationStudioSBOMGenerator:
         base_path = self.installation_directory / AUTOMATION_RUNTIME_PATH
         
         if not base_path.exists():
-            print(f"  ⚠️  Version path not found: {base_path}")
+            print(f"  {self.warning}  Version path not found: {base_path}")
             return []
         
         # interate through all subfolders of the base path
@@ -275,7 +311,7 @@ class AutomationStudioSBOMGenerator:
         library_2_path = self.installation_directory / LIBRARY_2_PATH
 
         if not library_2_path.exists():
-            print(f"  ⚠️  Library_2 path not found: {library_2_path}")
+            print(f"  {self.warning}  Library_2 path not found: {library_2_path}")
             return {}
 
         # interate through all subfolders of the Library_2 folder 
@@ -305,7 +341,7 @@ class AutomationStudioSBOMGenerator:
         base_path = self.installation_directory / VC_FIRMWARE_PATH
         
         if not base_path.exists():
-            print(f"  ⚠️  VisualizationControl path not found: {base_path}")
+            print(f"  {self.warning}  VisualizationControl path not found: {base_path}")
             return []
 
         # interate through all subfolders of the Firmware package base path and look for .br files 
@@ -334,7 +370,7 @@ class AutomationStudioSBOMGenerator:
         hardware_modules_path = self.installation_directory / HARDWARE_MODULES_PATH
 
         if not hardware_modules_path.exists():
-            print("  ⚠️  Hardware modules path not found.")
+            print(f"  {self.warning}  Hardware modules path not found.")
         
         # interate through all subfolders of the base path
         # the folder name is the base_path is the module_name. for example 0AC808.9-1
@@ -356,12 +392,12 @@ class AutomationStudioSBOMGenerator:
                             "description": description_en
                         }   
                     except ET.ParseError:  
-                        print(f"  ⚠️  XML parsing error in {module_path}")  
+                        print(f"  {self.warning}  XML parsing error in {module_path}")  
     
     def CreateComponentsList(self):
         """Create the list of components for the SBOM based on the collected information."""
         # Components should be stored in a dictionary with the configuration name as key and a list of components as value, this will allow to create a separate SBOM for each configuration with the correct components
-        print("🛠️  Creating Components List... ")
+        print(f"{self.debug}  Creating Components List... ")
 
         self._parse_automation_runtime_libraries()  # Parse the automation runtime libraries once to have the information available for all configurations
         self._parse_libraries_in_logical()  # Parse the libraries in logical once to have the information available for all configurations
@@ -370,7 +406,7 @@ class AutomationStudioSBOMGenerator:
         self._parse_vc_libraries()  # Parse the VisualizationControl libraries once to have the information available for all configurations
 
         for config in self.configurations:
-            print(f"  🛠️  Processing configuration: {config}")
+            print(f"  {self.debug}  Processing configuration: {config}")
             self.components[config] = []  # Initialize the components list for the current configuration
 
              # Add AutomationRuntime component if version information is available
@@ -405,12 +441,17 @@ class AutomationStudioSBOMGenerator:
                 tree = ET.parse(lib_path)
                 root = tree.getroot()
                 version = root.get("Version", "unknown")
+               # print(f'  ➕ Library in Logical: {lib_name} v{version}')
                 lib_name_lower = lib_name.lower()
+               # for tags in root:
+               #     if tags.tag == "{http://br-automation.co.at/AS/Library}Dependencies":
+               #         for dep in tags:
+               #             print(f'Abhängigkeit der Lib "{lib_name_lower}" --> {dep.attrib["ObjectName"]} Von Version: {dep.attrib.get("FromVersion", "unknown")} -> {dep.attrib.get("ToVersion", "unknown")}')
                 self.libraries_in_logical[lib_name_lower] = version  # Store library name and version
             except ET.ParseError:
-                print(f"  ⚠️  XML parsing error in {lib_path}")
+                print(f"  {self.warning}  XML parsing error in {lib_path}")
             except Exception as e:
-                print(f"  ⚠️  Error processing {lib_path}: {e}")
+                print(f"  {self.warning}  Error processing {lib_path}: {e}")
 
     def _parse_technology_packages(self):
         """Parse the technology package .br files to extract library information."""
@@ -509,9 +550,9 @@ class AutomationStudioSBOMGenerator:
                     #print(f"  ➕ TechnologyPackage-{package_name} v{package_version}")
 
         except ET.ParseError:
-            print(f"  ⚠️  XML parsing error in {self.apj_file}")
+            print(f"  {self.warning}  XML parsing error in {self.apj_file}")
         except Exception as e:
-            print(f"  ⚠️  Error processing {self.apj_file}: {e}")
+            print(f"  {self.warning}  Error processing {self.apj_file}: {e}")
 
     def _parse_cpu_pkg_file(self, config=None):
         """Parse a single cpu.pkg file for CPU information."""
@@ -520,7 +561,7 @@ class AutomationStudioSBOMGenerator:
         
         current_cpu_pkg = self.cpu_pkg_files.get(config)
         if not current_cpu_pkg: 
-            print(f"  ⚠️  No cpu.pkg file found for configuration '{config}'")
+            print(f"  {self.warning}  No cpu.pkg file found for configuration '{config}'")
             return
 
         try:
@@ -559,16 +600,16 @@ class AutomationStudioSBOMGenerator:
                     #print(f"  ➕ VisualizationControl v{vc_version}")
                 
         except ET.ParseError:
-            print(f"  ⚠️  XML parsing error in {current_cpu_pkg}")
+            print(f"  {self.warning}  XML parsing error in {current_cpu_pkg}")
         except Exception as e:
-            print(f"  ⚠️  Error processing {current_cpu_pkg}: {e}")
+            print(f"  {self.warning}  Error processing {current_cpu_pkg}: {e}")
 
     def _parse_sw_file(self, config=None):
         """Parse a single .sw file for software component information."""
         current_sw_file = self.sw_files.get(config)
         
         if not current_sw_file:
-            print(f"  ⚠️  No .sw file found for configuration '{config}'")
+            print(f"  {self.warning}  No .sw file found for configuration '{config}'")
             return
 
         # Use a namespace dictionary to avoid conflicts with 'http' package
@@ -641,7 +682,7 @@ class AutomationStudioSBOMGenerator:
                                      version = versionAttribute  # If there is no match in the technology libraries, use the version from binary.lby, but still mark it as not a B&R component, because it is not found in the technology libraries from Library_2, which are the most likely source for B&R libraries, this is to avoid false positives where a library is marked as B&R library just because there is a library with the same name in the automation runtime or VisualizationControl folders, but in reality it is a user library that just happens to have the same name as a library in the automation runtime or VisualizationControl                                
 
                             except ET.ParseError:
-                                print(f"  ⚠️  XML parsing error in {lby_file}")
+                                print(f"  {self.warning}  XML parsing error in {lby_file}")
                         else:
                             if lib_name_lower in self.technology_packages_libraries:
                                 _is_br_component = True
@@ -667,18 +708,17 @@ class AutomationStudioSBOMGenerator:
                         )                       
 
                         if not _is_br_component:
-                            print(f"  ⚠️  {lib_name} (version: {version}) - User-defined library, not identified as B&R component")
-
+                            print(f"  {self.warning}  {lib_name} (version: {version}) - User-defined library, not identified as B&R component")
 
             except ET.ParseError:
-                print(f"  ⚠️  XML parsing error in {sw_file_path}")
+                print(f"  {self.warning}  XML parsing error in {sw_file_path}")
 
     def _parse_hw_file(self, config=None):
         """Parse a single .hw file for hardware module information."""
         current_hw_file = self.hw_files.get(config)
         
         if not current_hw_file:
-            print(f"  ⚠️  No .hw file found for configuration '{config}'")
+            print(f"  {self.warning}  No .hw file found for configuration '{config}'")
             return
 
         # Use a namespace dictionary to avoid conflicts with 'http' package
@@ -725,7 +765,7 @@ class AutomationStudioSBOMGenerator:
                     added_modules.add(module_key)
 
             except ET.ParseError:
-                print(f"  ⚠️  XML parsing error in {hw_file_path}")
+                print(f"  {self.warning}  XML parsing error in {hw_file_path}")
   
     def _add_component(self, config=None, name=None, version=None, comp_type=None, is_br_component=False, description=None):
         """Add a component to the SBOM of the current configuration."""
@@ -740,12 +780,20 @@ class AutomationStudioSBOMGenerator:
                 }
             }
         else:
-            license_info = {
-                "license": {
-                    "name": "UNKNOWN",
-                    "url": "UNKNOWN"
+            if safe_name in self.licence_info:
+                license_info = {
+                    "license": {
+                        "name": self.licence_info[safe_name].get("license_name", self.license_name_default),
+                        "url": self.licence_info[safe_name].get("license_url", self.license_url_default)
+                    }
                 }
-            }
+            else:
+                license_info = {
+                    "license": {
+                        "name": self.license_name_default,
+                        "url": self.license_url_default
+                    }
+                }
 
         component = {
             "bom-ref": f"ref-{uuid.uuid4().hex[:8]}",
@@ -815,7 +863,7 @@ class AutomationStudioSBOMGenerator:
             output_path = self.output_directory / f"{config}_{output_file}"
             with open(output_path, 'w') as f:
                 json.dump(sbom, f, indent=4)
-            print(f"  ✅ SBOM generated for configuration '{config}' at: {output_path}")
+            print(f"  {self.success} SBOM generated for configuration '{config}' at: {output_path}")
 
 
 
@@ -835,6 +883,15 @@ if __name__ == "__main__":
     parser.add_argument(
         "--output-directory", default=None, help="Directory to write the generated SBOM files. Defaults to the project directory."
     )
+    parser.add_argument(
+        "--no-fancy",  action="store_true", help="Disable fancy output formatting."
+    )
+    parser.add_argument(
+        "--license-name", default="UNKNOWN", help="Name of the license to be used in the SBOM. If not provided, 'UNKNOWN' will be used."
+    )
+    parser.add_argument(
+        "--license-url", default="UNKNOWN", help="URL of the license to be used in the SBOM. If not provided, 'UNKNOWN' will be used."
+    )
     args = parser.parse_args()
 
     generator = AutomationStudioSBOMGenerator(
@@ -843,6 +900,9 @@ if __name__ == "__main__":
         args.installation_directory,
         args.customer_name,
         args.output_directory,
+        args.no_fancy,
+        args.license_name,
+        args.license_url
     )
     generator.generate_sbom()
 

--- a/src/automation_sbom_parserV1.py
+++ b/src/automation_sbom_parserV1.py
@@ -25,7 +25,7 @@ VC_FIRMWARE_PATH = "AS/VC/Firmware"
 HARDWARE_MODULES_PATH = "AS/Hardware/Modules"
 
 class AutomationStudioSBOMGenerator:
-    def __init__(self, project_path: str, export_libraries: bool, installation_directory: str, customer_name: str, output_directory: str, no_fancy: bool , license_name: str , license_url: str):
+    def __init__(self, project_path: str, export_libraries: bool, installation_directory: str, customer_name: str, output_directory: str, no_icons: bool , license_name: str , license_url: str):
         self.project_path = Path(project_path)
         self.export_libraries = export_libraries  # Store the switch value
         self.installation_directory = Path(installation_directory)
@@ -33,10 +33,10 @@ class AutomationStudioSBOMGenerator:
         self.license_name_default = license_name
         self.license_url_default = license_url
         self.output_directory = Path(output_directory) if output_directory else self.project_path
-        self.warning = '⚠️' if not no_fancy else 'WARNING'
-        self.info = '🔍' if not no_fancy else 'INFO'
-        self.success = '✅' if not no_fancy else 'SUCCESS'
-        self.debug = '🛠️' if not no_fancy else 'DEBUG'
+        self.warning = '⚠️' if not no_icons else 'WARNING'
+        self.info = '🔍' if not no_icons else 'INFO'
+        self.success = '✅' if not no_icons else 'SUCCESS'
+        self.debug = '🛠️' if not no_icons else 'DEBUG'
         if self.output_directory.exists():
             if not self.output_directory.is_dir():
                 print(f" {self.warning}  Output directory is not a directory: {self.output_directory}")
@@ -442,10 +442,6 @@ class AutomationStudioSBOMGenerator:
                 root = tree.getroot()
                 version = root.get("Version", "unknown")
                 lib_name_lower = lib_name.lower()
-                for tags in root:
-                    if tags.tag == "{http://br-automation.co.at/AS/Library}Dependencies":
-                        for dep in tags:
-                            print(f' {self.info} Abhängigkeit der Lib "{lib_name_lower}" --> {dep.attrib["ObjectName"]} Von Version: {dep.attrib.get("FromVersion", "unknown")} -> {dep.attrib.get("ToVersion", "unknown")}')
                 self.libraries_in_logical[lib_name_lower] = version  # Store library name and version
             except ET.ParseError:
                 print(f"  {self.warning}  XML parsing error in {lib_path}")

--- a/src/automation_sbom_parserV1.py
+++ b/src/automation_sbom_parserV1.py
@@ -90,7 +90,6 @@ class AutomationStudioSBOMGenerator:
         self._find_license_info_in_var_files(logical_folder_path)
 
     def _find_license_info_in_var_files(self, logical_folder_path: str):
-        _variable_files_in_libraries = {}
         self.licence_info = {} # "library_name": {"license_name": "name", "license_url": "url"}
         _var_files = self._find_logical_files_by_extension(".var")
         
@@ -115,9 +114,7 @@ class AutomationStudioSBOMGenerator:
                                 "license_url": license_url
                             }
                 except Exception as e:
-                    print(f"  {self.warning}  Error reading {var_file}: {e}")
-        
-        print(f"Found license information in .var files: {self.licence_info}")                    
+                    print(f"  {self.warning}  Error reading {var_file}: {e}")                  
 
     def _find_configurations(self):
         """Parse Physical.pkg to identify configurations."""
@@ -754,8 +751,9 @@ class AutomationStudioSBOMGenerator:
                             description=_description if _is_br_component else f"Software Library: {lib_name} TO BE CHECKED BY USER"
                         )                       
 
-                        if not _is_br_component:
-                            print(f"  {self.warning}  {lib_name} (version: {version}) - User-defined library, not identified as B&R component")
+                        #Show warning, only if there is not default user-licence set
+                        if not _is_br_component and self.license_name_default == 'UNKNOWN':
+                            print(f"  {self.warning} {lib_name} (version: {version}) - User-defined library, not identified as B&R component")
                 
             except ET.ParseError:
                 print(f"  {self.warning}  XML parsing error in {sw_file_path}")

--- a/src/automation_sbom_parserV1.py
+++ b/src/automation_sbom_parserV1.py
@@ -164,8 +164,10 @@ class AutomationStudioSBOMGenerator:
                 root = tree.getroot()
 
                 # Find all referenced files
-                for namespace in ["cfg", "pkg"]:
-                    referenced_files = root.findall(f".//{namespace}:Object[@Reference='true']", namespaces={namespace: "http://br-automation.co.at/AS/Configuration"})
+                #for namespace in ["cfg", "pkg"]:
+                for namespace in [{"cfg":"http://br-automation.co.at/AS/Configuration"}, {"pkg":"http://br-automation.co.at/AS/Package"}, {"cpu": "http://br-automation.co.at/AS/Cpu"}]:
+                    key = next(iter(namespace))  # Get the first key from the dictionary
+                    referenced_files = root.findall(f".//{key}:Object[@Reference='true']", namespaces=namespace)
                     for ref in referenced_files:
                         ref_file_path = ref.text.replace("\\", "/")  # Normalize path separators
                         ref_file_path = ref_file_path.lstrip("/")  # Remove leading slash if present

--- a/src/automation_sbom_parserV1.py
+++ b/src/automation_sbom_parserV1.py
@@ -5,9 +5,10 @@ Automation Studio SBOM Generator
 Parses an Automation Studio directory and generates a project-specific SBOM.
 """
 
+from importlib.resources import files
 import json
 import xml.etree.ElementTree as ET
-from pathlib import Path
+from pathlib import Path, WindowsPath
 from datetime import datetime, timezone
 import hashlib
 import uuid
@@ -91,30 +92,32 @@ class AutomationStudioSBOMGenerator:
     def _find_license_info_in_var_files(self, logical_folder_path: str):
         _variable_files_in_libraries = {}
         self.licence_info = {} # "library_name": {"license_name": "name", "license_url": "url"}
-        for subfolder in logical_folder_path.rglob("*"):
-            if subfolder.is_dir():
-                variable_files = list(subfolder.glob("*.var"))
-                if variable_files:
-                    for var_file in variable_files:
-                        # file öffnen, und nach license_name und license_url suchen
-                        try:
-                            with open(var_file, "r", encoding="utf-8") as f:
-                                content = f.read()
-                                license_name = None
-                                license_url = None
-                                for line in content.splitlines():
-                                    if line.startswith('"License name":'):
-                                        license_name = line.split(": ")[1].strip('"')
-                                    elif line.startswith('"License URL":'):
-                                        license_url = line.split(": ")[1].strip('"')
-                                if license_name or license_url:
-                                    self.licence_info[subfolder.name] = {
-                                        "license_name": license_name,
-                                        "license_url": license_url
-                                    }
-                        except Exception as e:
-                            print(f"  {self.warning}  Error reading {var_file}: {e}")
-                            
+        _var_files = self._find_logical_files_by_extension(".var")
+        
+        for var_file in _var_files:
+            #print(f'Var-File: {var_file}')
+            # file öffnen, und nach license_name und license_url suchen
+            #print(f'Var-Files: {var_file} -> {_var_files[var_file]}')
+            for file in _var_files[var_file]:
+                try:
+                    with open(file, "r", encoding="utf-8") as f:
+                        content = f.read()
+                        license_name = None
+                        license_url = None
+                        for line in content.splitlines():
+                            if line.startswith('"License name":'):
+                                license_name = line.split(": ")[1].strip('"')
+                            elif line.startswith('"License URL":'):
+                                license_url = line.split(": ")[1].strip('"')
+                        if license_name or license_url:
+                            self.licence_info[var_file] = {
+                                "license_name": license_name,
+                                "license_url": license_url
+                            }
+                except Exception as e:
+                    print(f"  {self.warning}  Error reading {var_file}: {e}")
+        
+        print(f"Found license information in .var files: {self.licence_info}")                    
 
     def _find_configurations(self):
         """Parse Physical.pkg to identify configurations."""
@@ -148,50 +151,100 @@ class AutomationStudioSBOMGenerator:
             if cpu_pkg:
                 self.cpu_pkg_files[config] = cpu_pkg[0]  # Assuming there's only one Cpu.pkg file
 
-    def _find_files_by_extension(self, extension: str, config: str):
+    def _find_physical_files_by_extension(self, extension: str, config: str) -> list:
         """ Generic method to find files with a specific extension for each configuration. """
         files_list = []
         config_path = self.project_path / "Physical" / config
+        # Look for file references in all .pkg files
+        pkg_files = list(config_path.rglob("*.pkg"))
 
         # Look for files with the given extension in the configuration folder
         files_list.extend(config_path.rglob(f"*{extension}"))
-
-        # Look for file references in all .pkg files
-        pkg_files = list(config_path.rglob("*.pkg"))
         for pkg_file in pkg_files:
+
             try:
                 tree = ET.parse(pkg_file)
                 root = tree.getroot()
-
+                namespace_uri = root.tag.split("}")[0].strip("{")
+                ns = {'ns': namespace_uri}  # Extract namespace from the root tag
                 # Find all referenced files
-                #for namespace in ["cfg", "pkg"]:
-                for namespace in [{"cfg":"http://br-automation.co.at/AS/Configuration"}, {"pkg":"http://br-automation.co.at/AS/Package"}, {"cpu": "http://br-automation.co.at/AS/Cpu"}]:
-                    key = next(iter(namespace))  # Get the first key from the dictionary
-                    referenced_files = root.findall(f".//{key}:Object[@Reference='true']", namespaces=namespace)
-                    for ref in referenced_files:
-                        ref_file_path = ref.text.replace("\\", "/")  # Normalize path separators
-                        ref_file_path = ref_file_path.lstrip("/")  # Remove leading slash if present
-                        full_ref_path = self.project_path / ref_file_path
+                referenced_files = root.findall(f".//ns:Object[@Reference='true']", namespaces=ns)
 
-                        if full_ref_path.suffix == extension:
-                            files_list.append(full_ref_path)  # Store the full path for later parsing
+                for ref in referenced_files:
+                    ref_file_path = ref.text.replace("\\", "/")  # Normalize path separators
+                    ref_file_path = ref_file_path.lstrip("/")  # Remove leading slash if present
+                    #If the referenced file path is relative, prepend the project path to get the full path, if not, use the referenced file path as is
+                    if not (ref_file_path[1] == ":"):
+                        full_ref_path = self.project_path / ref_file_path
+                    else:
+                        full_ref_path = Path(ref_file_path)
+
+                    if full_ref_path.suffix == extension:
+                        files_list.append(full_ref_path)  # Store the full path for later parsing
 
             except ET.ParseError:
                 print(f"  {self.warning}  XML parsing error in {pkg_file}")
 
         return files_list
 
+    def _find_logical_files_by_extension(self, extension: str) -> list:
+        """ Generic method to find files with a specific extension for each configuration. """
+        file_dict = {}
+        config_path = self.project_path / 'Logical'  # If no config is specified, search in the base path
+        # Look for file references in all .prg files
+        prg_files = list(config_path.rglob("*.prg"))
+        # Look for files with the given extension in the configuration folder
+        file_list = list(config_path.rglob(f"*{extension}"))
+
+        for file in file_list:
+            task_name = file.parts[-2]  # Get the task name from the .prg file name
+            if task_name not in file_dict:
+                file_dict[task_name] = [file]
+                continue
+            file_dict[task_name].append(file)
+
+        for prg_file in prg_files:
+
+            try:
+                tree = ET.parse(prg_file)
+                root = tree.getroot()
+                namespace_uri = root.tag.split("}")[0].strip("{")
+                ns = {'ns': namespace_uri}  # Extract namespace from the root tag
+
+                # Find all referenced files
+                referenced_files = root.findall(f".//ns:File[@Reference='true']", namespaces=ns)
+                for ref in referenced_files:
+                    ref_file_path = ref.text.replace("\\", "/")  # Normalize path separators
+                    ref_file_path = ref_file_path.lstrip("/")  # Remove leading slash if present
+                    #If the referenced file path is relative, prepend the project path to get the full path, if not, use the referenced file path as is
+                    if not (ref_file_path[1] == ":"):
+                        full_ref_path = self.project_path / ref_file_path
+                    else:
+                        full_ref_path = Path(ref_file_path)
+
+                    if full_ref_path.suffix == extension:
+                        task_name = prg_file.parts[-2]  # Get the task name from the .prg file name
+                        if task_name not in file_dict:
+                            file_dict[task_name] = [full_ref_path]
+                            continue
+                        file_dict[task_name].append(full_ref_path)
+
+            except ET.ParseError:
+                print(f"  {self.warning}  XML parsing error in {prg_file}")
+
+        return file_dict
+
     def _find_all_sw_files(self):
         """ Find all *.sw files for each configuration. """
         self.sw_files = {}
         for config in self.configurations:
-            self.sw_files[config] = self._find_files_by_extension(".sw", config)
+            self.sw_files[config] = self._find_physical_files_by_extension(".sw", config)
 
     def _find_all_hw_files(self):
         """ Find all *.hw files for each configuration. """
         self.hw_files = {}
         for config in self.configurations:
-            self.hw_files[config] = self._find_files_by_extension(".hw", config)
+            self.hw_files[config] = self._find_physical_files_by_extension(".hw", config)
 
     def _get_configurationIDs(self):
         """Extract the ConfigurationID from *.hw files per configuration."""
@@ -760,8 +813,6 @@ class AutomationStudioSBOMGenerator:
         _path = _logical_path / _task_path
         _prg_files = []
         _task_version = "1.0.0"
-
-        #self._find_license_info_in_var_files(_path)  # Check for license information in the .var files of the task
 
         # parse _path for files ending with ".prg" 
         for file in Path(_path).rglob("*.prg"):

--- a/src/automation_sbom_parserV1.py
+++ b/src/automation_sbom_parserV1.py
@@ -441,12 +441,11 @@ class AutomationStudioSBOMGenerator:
                 tree = ET.parse(lib_path)
                 root = tree.getroot()
                 version = root.get("Version", "unknown")
-               # print(f'  ➕ Library in Logical: {lib_name} v{version}')
                 lib_name_lower = lib_name.lower()
-               # for tags in root:
-               #     if tags.tag == "{http://br-automation.co.at/AS/Library}Dependencies":
-               #         for dep in tags:
-               #             print(f'Abhängigkeit der Lib "{lib_name_lower}" --> {dep.attrib["ObjectName"]} Von Version: {dep.attrib.get("FromVersion", "unknown")} -> {dep.attrib.get("ToVersion", "unknown")}')
+                for tags in root:
+                    if tags.tag == "{http://br-automation.co.at/AS/Library}Dependencies":
+                        for dep in tags:
+                            print(f' {self.info} Abhängigkeit der Lib "{lib_name_lower}" --> {dep.attrib["ObjectName"]} Von Version: {dep.attrib.get("FromVersion", "unknown")} -> {dep.attrib.get("ToVersion", "unknown")}')
                 self.libraries_in_logical[lib_name_lower] = version  # Store library name and version
             except ET.ParseError:
                 print(f"  {self.warning}  XML parsing error in {lib_path}")


### PR DESCRIPTION
added tasks to the SBOM (only tested with .st Tasks so far)

added arguments:
--no-icons
	- changes ⚠️ to "WARNING", and other icons accordingly
--license_name
	- Default name for the customer-licence for everything that is no B&R component
--license-url
 - Default url for the customer-licence for everything that is no B&R component

also Added the option to declare a license name and url for each and every library and task as comment in .var File


Changes made by Stefan Holz, B&R Germany Office Southwest.